### PR TITLE
Fix code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/CargoHubRefactor/Controllers/ReportingController.cs
+++ b/CargoHubRefactor/Controllers/ReportingController.cs
@@ -30,7 +30,7 @@ namespace CargoHubRefactor.Controllers
                 return BadRequest("Entity is required.");
             if (!fromDate.HasValue || !toDate.HasValue)
                 return BadRequest("fromDate and toDate are required.");
-            if (entity.Contains("..") || entity.Contains("/") || entity.Contains("\\"))
+            if (!IsValidEntity(entity))
                 return BadRequest("Invalid entity value.");
 
             try
@@ -71,4 +71,8 @@ namespace CargoHubRefactor.Controllers
             return File(fileBytes, "text/csv", fileName);
         }
     }
-}
+        private bool IsValidEntity(string entity)
+        {
+            return entity.All(c => char.IsLetterOrDigit(c) || c == '_');
+        }
+    }

--- a/CargoHubRefactor/Services/ReportingService.cs
+++ b/CargoHubRefactor/Services/ReportingService.cs
@@ -73,7 +73,11 @@ namespace CargoHubRefactor.Services
         private void WriteReportToFile(string entity, DateTime fromDate, DateTime toDate, int? warehouseId, IEnumerable<object> reportData)
         {
             string fileName = $"{entity}_Report_{fromDate:yyyyyMMdd}_{toDate:yyyyMMdd}_Id_{warehouseId}.txt";
-            string filePath = Path.Combine(_reportDirectory, fileName);
+            string filePath = Path.GetFullPath(Path.Combine(_reportDirectory, fileName));
+            if (!filePath.StartsWith(_reportDirectory))
+            {
+                throw new UnauthorizedAccessException("Invalid file path.");
+            }
 
             using (StreamWriter writer = new StreamWriter(filePath, false))
             {


### PR DESCRIPTION
Fixes [https://github.com/Efroem/Processing-and-Tools-Team-2/security/code-scanning/1](https://github.com/Efroem/Processing-and-Tools-Team-2/security/code-scanning/1)

To fix the problem, we need to ensure that the `entity` parameter is validated more rigorously before it is used to construct a file path. Specifically, we should ensure that the `entity` parameter only contains valid characters and does not allow any form of path traversal. Additionally, we should ensure that the constructed file path remains within the intended directory.

The best way to fix this problem is to:
1. Add a validation method to check that the `entity` parameter only contains alphanumeric characters and underscores.
2. Ensure that the constructed file path remains within the `_reportDirectory`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
